### PR TITLE
It's not a url shortiner anymore

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@
 * [bit.ly](https://bitly.com)
 * [bitly.kr](https://bitly.kr) - Korean URL Shortener Service
 * [bl.ink](https://www.bl.ink)
-* [buff.ly](https://buff.ly)
 * [clicky.me](https://clicky.me)
 * [cutt.ly](https://cutt.ly)
 * [Dub.co](https://dub.co)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the list of URL shortener services by removing the buff.ly entry, streamlining the available options for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->