### PR TITLE
Add fwd2.app to awesome-url-shortener

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 * [cutt.ly](https://cutt.ly)
 * [Dub.co](https://dub.co)
 * [fox.ly](https://foxlyme.com/) - Optimize your URL
+* [fwd2.app](https://fwd2.app) - Forward to. A URL shortener with a one-time revocation key.
 * [Go2ULink](https://go2u.link/) - Private URL Shortener with Chorme Extension (https://www.go2u.link/Extension)
 * [han.gl](https://han.gl) - Korean URL Shortener Service
 * [is.gd](https://is.gd)


### PR DESCRIPTION
Adds fwd2.app to the list of URL shortener services.

fwd2, short for Forward to, is a URL shortener built around a one-time revocation key. When a link is shortened, a key is shown once and can later be used to revoke that link. If the key is lost, the link stays live.

I thought it would be a good fit because the revocation model gives it a different approach from most traditional shorteners.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added **fwd2.app** to the list of supported URL shortener services with details about its forwarding capabilities and revocation features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->